### PR TITLE
Add environment-based configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration for WOHRatingBot
+BOT_TOKEN=YOUR_TELEGRAM_BOT_TOKEN
+DATABASE_URL=sqlite:///woh_rating.db
+DEBUG=False

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ The repository now contains basic placeholders for these components so developme
    pip install -r requirements.txt
    ```
 3. Initialize the SQLite database and run migrations with Alembic.
-4. Provide your Telegram API token in the environment or a config file.
+4. Create a `.env` file based on `.env.example` and set the required
+   environment variables (`BOT_TOKEN`, `DATABASE_URL`, `DEBUG`).
 5. Start the services during development:
    ```bash
    python bot/main.py         # Telegram bot

--- a/bot/main.py
+++ b/bot/main.py
@@ -2,12 +2,11 @@ from aiogram import Bot, Dispatcher, types
 from aiogram.utils import executor
 import logging
 
-# TODO: move to config
-API_TOKEN = "YOUR_TELEGRAM_BOT_TOKEN"
+from config import BOT_TOKEN, DEBUG
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG if DEBUG else logging.INFO)
 
-bot = Bot(token=API_TOKEN)
+bot = Bot(token=BOT_TOKEN)
 dp = Dispatcher(bot)
 
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+import os
+
+BOT_TOKEN = os.getenv("BOT_TOKEN", "YOUR_TELEGRAM_BOT_TOKEN")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///woh_rating.db")
+DEBUG = os.getenv("DEBUG", "False").lower() in ("1", "true", "yes")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 
-app = FastAPI(title="WOH Rating Web App")
+from config import DEBUG
+
+app = FastAPI(title="WOH Rating Web App", debug=DEBUG)
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- introduce a simple `config.py` that reads `BOT_TOKEN`, `DATABASE_URL` and `DEBUG`
- provide a `.env.example` template for environment variables
- use the new configuration in `bot/main.py` and `webapp/app.py`
- update README with instructions for creating a `.env` file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad53f9f7883218021882fbe6fa593